### PR TITLE
minor cleanup esp to make this work with langgraph 0.4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/eaia/main/find_meeting_time.py
+++ b/eaia/main/find_meeting_time.py
@@ -2,10 +2,10 @@
 
 from datetime import datetime
 
+from langchain.agents.react.agent import create_react_agent
 from langchain_core.messages import ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import create_react_agent
 
 from eaia.gmail import get_events_for_days
 from eaia.schemas import State

--- a/eaia/main/triage.py
+++ b/eaia/main/triage.py
@@ -15,7 +15,7 @@ from eaia.main.config import get_config
 
 triage_prompt = """You are {full_name}'s executive assistant. You are a top-notch executive assistant who cares about {name} performing as well as possible.
 
-{background}. 
+{background}.
 
 {name} gets lots of emails. Your job is to categorize the below email to see whether is it worth responding to.
 

--- a/eaia/schemas.py
+++ b/eaia/schemas.py
@@ -1,6 +1,6 @@
 from typing import Annotated, List, Literal
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langgraph.graph.message import AnyMessage
+from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-langgraph = "^0.2.48"
+langgraph = "^0.4.5"
 langgraph-checkpoint = "^2.0.0"
 langchain = "^0.3.9"
 langchain-openai = "^0.2"


### PR DESCRIPTION
* Update create_react_graph import to new location
* Update TOML to support 0.4.5 (since that's what `langgraph-cli` wants now)
* This also allows the use of `--allow-blocking` in `langgraph dev`, which is now required
* add `.python-version` to `.gitignore` since `pyenv` is explicitly recommended in `README.md`